### PR TITLE
build: Allow the the compiler var to be overridden.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-CROSS_COMPILE=arm-linux-gnueabihf
+CROSS_COMPILE ?= arm-linux-gnueabihf-
+CC	?= $(CROSS_COMPILE)gcc
 
 all:
-	$(CROSS_COMPILE)-gcc mdio-tool.c -o mdio-tool
+	$(CC) mdio-tool.c -o mdio-tool
 clean:
 	rm mdio-tool


### PR DESCRIPTION
Allows to be compiled for different architectures. Integration into a bitbake recipe is now easily possible without patching.
